### PR TITLE
Empty list fix

### DIFF
--- a/MMM-Gas.js
+++ b/MMM-Gas.js
@@ -10,8 +10,8 @@ Module.register("MMM-Gas", {
         updateInterval: 12 * 60 * 60 * 1000,
         zip: "14904",
         items: 10,
-				typeGas: "",				//premium, mid-grade, diesel, or blank for regular
-				sortBy: "distance"	//distance, price
+        typeGas: "",				//premium, mid-grade, diesel, or blank for regular
+        sortBy: "distance"	//distance, price
     },
 	
     voice: {

--- a/MMM-Gas.js
+++ b/MMM-Gas.js
@@ -9,7 +9,9 @@ Module.register("MMM-Gas", {
     defaults: {
         updateInterval: 12 * 60 * 60 * 1000,
         zip: "14904",
-        items: "10"
+        items: 10,
+				typeGas: "",				//premium, mid-grade, diesel, or blank for regular
+				sortBy: "distance"	//distance, price
     },
 	
     voice: {
@@ -79,7 +81,7 @@ Module.register("MMM-Gas", {
         var gas = this.gas;
 
 
-        for (i = 0; i < this.gas.length; i++) {
+        for (i = 0; i < Math.min(this.gas.length, this.config.items); i++) {
             var gas = this.gas[i];
 
             var name = gas.name.replace(/\#.*/, '');

--- a/README.md
+++ b/README.md
@@ -21,7 +21,10 @@ https://github.com/fewieden/MMM-Fuel
         module: 'MMM-Gas',
         position: 'top_left',
         config: { 
-	       zip : "14904"  
+	       zip : "14904",
+				 typeGas: "mid-grade", //can be "mid-grade", "premium", or "diesel".  Leave blank for regular gas prices
+				 sortBy: "price",	//can be "distance" or "price"
+				 items: 10	//number of gas stations to display
 	     }
        },
 

--- a/README.md
+++ b/README.md
@@ -21,10 +21,10 @@ https://github.com/fewieden/MMM-Fuel
         module: 'MMM-Gas',
         position: 'top_left',
         config: { 
-	       zip : "14904",
-				 typeGas: "mid-grade", //can be "mid-grade", "premium", or "diesel".  Leave blank for regular gas prices
-				 sortBy: "price",	//can be "distance" or "price"
-				 items: 10	//number of gas stations to display
+		zip : "14904",
+		typeGas: "mid-grade", //can be "mid-grade", "premium", or "diesel".  Leave blank for regular gas prices
+		sortBy: "price",	//can be "distance" or "price"
+		items: 10	//number of gas stations to display
 	     }
        },
 

--- a/node_helper.js
+++ b/node_helper.js
@@ -15,30 +15,23 @@ module.exports = NodeHelper.create({
     },
 
      getGAS: function() {
-        request("https://www.autoblog.com/" + this.config.zip + "-gas-prices/", (error, response, body) => {
+        request("https://www.autoblog.com/" + this.config.zip + "-gas-prices/" + this.config.typeGas, (error, response, body) => {
             if (!error && response.statusCode == 200) {
                 const $ = cheerio.load(body);
-
                 const gasset = [];
-
-                $('.stations-list tbody tr').each(function(i, elem) {
-                    const href = decodeURI($(elem).find('.name a').attr('href')).split('=');
-					console.log(href);
-                    const address = href[href.length - 1];
-					
-
+                $('.shop').each(function(i, elem) {
                     const gaslist = {
-                        name: $(elem).find('.name a').text(),
-                        ppg: $(elem).find('.ppg').text().replace(/[\n\t\r]/g, ""),
+                        name: $(elem).find('.name h4').text(),
+                        ppg: $(elem).find('.price').text().match(/^\$(([1-9]\d*)?\d)(\.\d{2})/g)[0],
                         dist: $(elem).find('.dist').text().replace(/[\n\t\r]/g, ""),
-                        address,
-						//link
+                        address: $(elem).find('.name address').text(),
+												updated: $(elem).find('.time').text(),
                     };
-                    console.log(gaslist);
                     gasset.push(gaslist);
-					
                 });
-
+								if(this.config.sortBy == 'price') {
+										gasset.sort((a,b) => eval(a.ppg.slice(1)) - eval(b.ppg.slice(1)) );
+								}
                 this.sendSocketNotification("GAS_RESULT", gasset);
             }
         });

--- a/node_helper.js
+++ b/node_helper.js
@@ -25,13 +25,13 @@ module.exports = NodeHelper.create({
                         ppg: $(elem).find('.price').text().match(/^\$(([1-9]\d*)?\d)(\.\d{2})/g)[0],
                         dist: $(elem).find('.dist').text().replace(/[\n\t\r]/g, ""),
                         address: $(elem).find('.name address').text(),
-												updated: $(elem).find('.time').text(),
+                        updated: $(elem).find('.time').text(),
                     };
                     gasset.push(gaslist);
                 });
-								if(this.config.sortBy == 'price') {
-										gasset.sort((a,b) => eval(a.ppg.slice(1)) - eval(b.ppg.slice(1)) );
-								}
+                if(this.config.sortBy == 'price') {
+                    gasset.sort((a,b) => eval(a.ppg.slice(1)) - eval(b.ppg.slice(1)) );
+                }
                 this.sendSocketNotification("GAS_RESULT", gasset);
             }
         });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mmm-gas",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Inspired by [NHubbard's Snow Plugin](https://github.com/nhubbard/MagicPlugins/tree/master/snow) I created a little more realistic snow plugin to improve your winter experience!",
   "main": "MMM-Gas.js",
   "scripts": {


### PR DESCRIPTION
Fixes the empty list problem, plus:

You can now get fuel data for regular (default), mid-grade, premium, and diesel. I also threw in a way to sort by price or distance (default). I saw you had an items variable in the default config section as well. I assume that was to only show X number of items. I added that to your for loop that iterates through the gas array.